### PR TITLE
Download wordless plugin from github

### DIFF
--- a/lib/wordless/wordless_cli.rb
+++ b/lib/wordless/wordless_cli.rb
@@ -51,8 +51,9 @@ module Wordless
       info("Installing and activating plugin...")
 
       at_wordpress_root do
+        github_url = 'https://github.com/welaika/wordless/archive/master.zip'
         error("Directory '#{plugins_path}' not found.") unless File.directory?(plugins_path)
-        if run_command("wp plugin install wordless --activate")
+        if run_command("wp plugin install #{github_url} --activate")
           success("Done!")
         else
           error("There was an error installing and/or activating the Wordless plugin.")


### PR DESCRIPTION
This update use `wp-cli` to download the WordLess plugin directly from github at master branch.
Wordpress plugin repository (SVN) doesn't allow to update plugins that are not compatible to PHP 5.6 (!!!) so now the wordless_gem download an outdated version of plugin.